### PR TITLE
restore secrets example file

### DIFF
--- a/config/secrets-example.php
+++ b/config/secrets-example.php
@@ -1,0 +1,18 @@
+<?
+// set site_url variable based on detected server name
+$parts = explode('.', $_SERVER["SERVER_NAME"]);
+if( $parts[0] == 'codame' && $parts[1] == 'com' ){
+  $site_url = "http://codame.com";
+}else if( $parts[0] == 'dev' ){
+  $site_url = 'http://dev.codame.com';
+}else{
+  $site_url = 'http://codame.dev'; // change this to match your local site name
+}
+$codame_api_key = "fill in";
+$mysql_host = "fill in";
+$mysql_user = "fill in";
+$mysql_pw   = "fill in";
+$mysql_db   = "fill in";
+$admin_user = "fill in";
+$admin_pw   = "fill in";
+?>


### PR DESCRIPTION
[Docs](https://github.com/CODAME/codame-website/blob/master/developing.md) reference a `config/secrets-example.php` file, but none exists.

looks like it was accidentally deleted here:
https://github.com/CODAME/codame-website/commit/2a86b16f7eaeb43245b6958ac8a270fee897481d#diff-751221c3c0103ffcdefff61cb83c8e75