### PR TITLE
add trailing slash fix to src files as well

### DIFF
--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -1,7 +1,7 @@
 # Allow Rewrites:
-Options +FollowSymLinks  
-RewriteEngine On  
-RewriteCond %{SCRIPT_FILENAME} !-d  
+Options +FollowSymLinks
+RewriteEngine On
+RewriteCond %{SCRIPT_FILENAME} !-d
 RewriteCond %{SCRIPT_FILENAME} !-f
 
 # any redirects that were created while this site has been live:
@@ -12,7 +12,7 @@ rewriterule ^artex(.*)$ http://codame.com/events/artificial-experiences$1 [r=301
 # remove trailing slash
 RewriteRule (.*)/$ /$1 [L,R=301]
 
-# Categories: 
+# Categories:
 RewriteRule ^artists\/?$ ./category.php?table=artists
 RewriteRule ^events\/?$ ./category.php?table=events
 RewriteRule ^projects\/?$ ./category.php?table=projects

--- a/src/root-files/.htaccess
+++ b/src/root-files/.htaccess
@@ -1,7 +1,7 @@
 # Allow Rewrites:
-Options +FollowSymLinks  
-RewriteEngine On  
-RewriteCond %{SCRIPT_FILENAME} !-d  
+Options +FollowSymLinks
+RewriteEngine On
+RewriteCond %{SCRIPT_FILENAME} !-d
 RewriteCond %{SCRIPT_FILENAME} !-f
 
 # any redirects that were created while this site has been live:
@@ -9,7 +9,10 @@ RewriteCond %{SCRIPT_FILENAME} !-f
 rewriterule ^projects/modbod3d(.*)$ http://codame.com/projects/modbod$1 [r=301,nc]
 rewriterule ^artex(.*)$ http://codame.com/events/artificial-experiences$1 [r=301,nc]
 
-# Categories: 
+# remove trailing slash
+RewriteRule (.*)/$ /$1 [L,R=301]
+
+# Categories:
 RewriteRule ^artists\/?$ ./category.php?table=artists
 RewriteRule ^events\/?$ ./category.php?table=events
 RewriteRule ^projects\/?$ ./category.php?table=projects


### PR DESCRIPTION
@jouncealimb I think i figured this out!

(hopefully) resolves https://github.com/CODAME/codame-website/issues/15 

I noticed that this line was disappearing from the `dist/` version of .htaccess because it was added straight to the `dist/` version of the file (instead of `src/.htaccess`): https://github.com/CODAME/codame-website/commit/04dc1ffe134ed44918d276f6138111a41735e51f

I still don't have my dev env successfully set up yet, so this is untested. But it seemed like a simple fix, as long as I'm correct in assuming that the deploy process involves a `gulp`.

Lines other than the "# remove trailing slash" ones are just whitespace changes